### PR TITLE
use deep copy when merging options

### DIFF
--- a/src/jsTreeBind.js
+++ b/src/jsTreeBind.js
@@ -24,7 +24,7 @@
             warn("You can only define one root element to bind to the jsTree. Additional elements ignored.");
 
         //Merge this configuration object with whatever the user has passed in
-        var merged = $.extend(getDefaults(template), options);
+        var merged = $.extend(true, getDefaults(template), options);
 
         //Actually call jstree()
         tree.jstree(merged);


### PR DESCRIPTION
using recursive "deep copy" while merging the options will allow the user to define "core" options aswell.
Example:

``` javascript
$("#jstree").jsTreeBind("#tree-template", {"core": {"multiple": false}}); // this will fail without 'deep-copy'
```
